### PR TITLE
Adds search and copy code button to docs page. Closes #24

### DIFF
--- a/src/panels/WebViewPanels.ts
+++ b/src/panels/WebViewPanels.ts
@@ -69,7 +69,8 @@ export class WebViewPanels implements WebviewViewProvider {
         vscode.ViewColumn.One,
         {
           enableScripts: true,
-          localResourceRoots: [this.context.extensionUri]
+          localResourceRoots: [this.context.extensionUri],
+          enableFindWidget: true
         }
       );
 

--- a/webview-ui/docsView/components/docsComponent/Docs.css
+++ b/webview-ui/docsView/components/docsComponent/Docs.css
@@ -2,3 +2,19 @@
     text-align: right;
     padding-right: 50px;
 }
+
+.copy-code {
+    background: rgba(0,0,0,0.05);
+    padding: 10px 7px 7px;
+    box-shadow: 0px 0px 5px #111;
+}
+
+.copy-code vscode-button {
+    float: right;
+    margin-top: -10px;
+}
+
+.copy-code pre code {
+    word-break: break-word;
+    white-space: initial;
+}

--- a/webview-ui/docsView/components/docsComponent/Docs.css
+++ b/webview-ui/docsView/components/docsComponent/Docs.css
@@ -16,5 +16,5 @@
 
 .copy-code pre code {
     word-break: break-word;
-    white-space: initial;
+    white-space: break-spaces;
 }

--- a/webview-ui/docsView/components/docsComponent/Docs.tsx
+++ b/webview-ui/docsView/components/docsComponent/Docs.tsx
@@ -32,9 +32,29 @@ export default class Docs extends React.Component<IDocsProps, IDocsState> {
           </VSCodeButton>
         </div>
         <div className='docs-content'>
-          <ReactMarkdown>{docs}</ReactMarkdown>
+          <ReactMarkdown
+            components={{
+              pre({ ...props }) {
+                const handleCopyCode = (codeChunk: React.ReactElement) => {
+                  const code = codeChunk.props.children[0];
+                  if (typeof code === 'string') {
+                    navigator.clipboard.writeText(code);
+                  }
+                };
+
+                return (
+                  <div className='copy-code'>
+                    <VSCodeButton appearance="icon" onClick={() => handleCopyCode({ ...props }?.children[0] as React.ReactElement)}>
+                      <span className='codicon codicon-copy'></span>
+                    </VSCodeButton>
+                    <pre {...props}></pre>
+                  </div>
+                );
+              }
+            }}
+          >{docs}</ReactMarkdown>
         </div>
-      </div>
+      </div >
     );
   }
 

--- a/webview-ui/docsView/components/docsComponent/Docs.tsx
+++ b/webview-ui/docsView/components/docsComponent/Docs.tsx
@@ -54,7 +54,7 @@ export default class Docs extends React.Component<IDocsProps, IDocsState> {
             }}
           >{docs}</ReactMarkdown>
         </div>
-      </div >
+      </div>
     );
   }
 


### PR DESCRIPTION
## 🎯 Aim

The aim is to add search page functionality on docs view and copy code button on code block 

## 📷 Result

![image](https://user-images.githubusercontent.com/58668583/230524834-719f66f6-9ae1-4552-985b-ad0d820109fa.png)

## ✅ What was done

- [X] Added custom react component to mdx for the copy code block 
- [X] Modified webview UI panel for docs view to add search functionality

## 🔗 Related issue

Closes: #24